### PR TITLE
Add error action creator

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -28,4 +28,13 @@ declare function action<T>(...args: T): $Call<typeof actionResult, T>
 export function action(payload, meta) {
   return (meta !== undefined ? { payload, meta } : { payload })
 }
+
+declare function errorResult<P>([P]): {|payload: P, error: true|}
+declare function errorResult<P, M>([P, M]): {|payload: P, error: true, meta: M|}
+
+declare function error<T>(...args: T): $Call<typeof errorResult, T>
+
+export function error(payload, meta) {
+  return (meta !== undefined ? { payload, error: true, meta } : { payload, error: true })
+}
 /* eslint-enable no-redeclare */


### PR DESCRIPTION
It is for covering case about creating actions with `error` property. It is compatible with [FSA's `error`](https://github.com/redux-utilities/flux-standard-action#error).

Example of use:

```js
import {createActions, action, empty, error} from 'typed-actions'

export const UPDATE_ERROR = '@namespace/UPDATE_ERROR'

const {
    [UPDATE_ERROR]: updateError,
} = createActions({
    /**
     * {type: UPDATE_ERROR, payload: Error, error: true, meta: {sync: true}}
     */
    [UPDATE_ERROR]: (err: Error) => error(err, {sync: true}),
})

dispatch(updateError(new Error('My error')))

```

PS: I didn't find how to run tests in the project, so I skipped writing the tests for the PR.